### PR TITLE
Sorting results by numeric value, not alphabetic

### DIFF
--- a/public/javascripts/result_edit.js
+++ b/public/javascripts/result_edit.js
@@ -52,7 +52,7 @@ var ResultListUpdater = Behavior.create({
   _ajaxParameters : function() {
     console.log("in ajaxParameters, this.results is " + this.results)
     if (this.results.any()) {
-      return { 'min_id' : this.results.map(function(res) { return res.id }).sort().last() }
+      return { 'min_id' : this.results.map(function(res) { return res.id }).sort(function(a,b) {return a>b;}).last() }
     } else {
       return {}
     }


### PR DESCRIPTION
Numeroiden syöttösivulla (timer/:id/results) tulokset lataantuivat osittain aina uudestaan, kun yli 100 tulosta, kun otettiin aakkosjärjestyksessä viimeinen (99) uusien tulosten hakukohdaksi.